### PR TITLE
POST requests should be in Shift_JIS encoding?

### DIFF
--- a/lib/gmo/http_services.rb
+++ b/lib/gmo/http_services.rb
@@ -50,7 +50,7 @@ module GMO
           def self.encode_params(param_hash)
             ((param_hash || {}).collect do |key_and_value|
               key_and_value[1] = MultiJson.dump(key_and_value[1]) if key_and_value[1].class != String
-              "#{key_and_value[0].to_s}=#{CGI.escape key_and_value[1]}"
+              "#{key_and_value[0].to_s}=#{CGI.escape key_and_value[1].encode('Shift_JIS')}"
             end).join("&")
           end
 


### PR DESCRIPTION
While I was testing some convenience store payments, sometimes I was getting error

M01010013 / 氏名に不正な文字が含まれています。
and
M01011013 / フリガナに不正な文字が含まれています。

So, I did a little more digging and found that POST requests should be in Shift_JIS encoding (021_制限事項一覧_1.19.pdf page 23)

I'm not sure if I did it the right way in this pull request, but it seems to be working now.
