### PR TITLE
Support Pay-easy payment

### DIFF
--- a/fixtures/vcr_cassettes/GMO_Payment_ShopAPI/_entry_tran_pay_easy_gets_data_about_a_transaction.yml
+++ b/fixtures/vcr_cassettes/GMO_Payment_ShopAPI/_entry_tran_pay_easy_gets_data_about_a_transaction.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<HOST>/payment/EntryTranPayEasy.idPass
+    body:
+      encoding: UTF-8
+      string: OrderID=1448103619&Amount=100&ShopID=<SHOP_ID>&ShopPass=<SHOP_PASS>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 21 Nov 2015 11:00:19 GMT
+      Content-Type:
+      - text/plain;charset=Windows-31J
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: AccessID=282b61afb9cabee8e72d49db77c08e2f&AccessPass=9c4883358947a15683f8a63f5fc7aef4
+    http_version: 
+  recorded_at: Sat, 21 Nov 2015 11:00:19 GMT
+recorded_with: VCR 3.0.0

--- a/fixtures/vcr_cassettes/GMO_Payment_ShopAPI/_exec_tran_pay_easy_gets_data_about_a_transaction.yml
+++ b/fixtures/vcr_cassettes/GMO_Payment_ShopAPI/_exec_tran_pay_easy_gets_data_about_a_transaction.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<HOST>/payment/EntryTranPayEasy.idPass
+    body:
+      encoding: UTF-8
+      string: OrderID=1448105474&Amount=100&ShopID=<SHOP_ID>&ShopPass=<SHOP_PASS>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 21 Nov 2015 11:31:15 GMT
+      Content-Type:
+      - text/plain;charset=Windows-31J
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: AccessID=eb18bcc94bd6027929b2cb401b5eff9b&AccessPass=e79f0cbfb6b00343beb85eb8df873277
+    http_version: 
+  recorded_at: Sat, 21 Nov 2015 11:31:15 GMT
+- request:
+    method: post
+    uri: https://<HOST>/payment/ExecTranPayEasy.idPass
+    body:
+      encoding: UTF-8
+      string: OrderID=1448105474&AccessID=eb18bcc94bd6027929b2cb401b5eff9b&AccessPass=e79f0cbfb6b00343beb85eb8df873277&CustomerName=%83y%83C%91%BE%98Y&CustomerKana=%83y%83C%83%5E%83%8D%83E&TelNo=0300000001&ReceiptsDisp11=RSpec+Helpdesk&ReceiptsDisp12=0300000001&ReceiptsDisp13=00%3A00-00%3A15&ShopID=<SHOP_ID>&ShopPass=<SHOP_PASS>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 21 Nov 2015 11:31:16 GMT
+      Content-Type:
+      - text/plain;charset=Windows-31J
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: OrderID=1448105474&CustID=WNT05476383&BkCode=58021&ConfNo=3769&EncryptReceiptNo=LB7OigJvPDmbWxAqB8OY&PaymentTerm=20151201235959&TranDate=20151121203100&CheckString=6a7c5cb87d1857e9b9088d65480545e3
+    http_version: 
+  recorded_at: Sat, 21 Nov 2015 11:31:16 GMT
+recorded_with: VCR 3.0.0

--- a/lib/gmo/shop_api.rb
+++ b/lib/gmo/shop_api.rb
@@ -61,6 +61,16 @@ module GMO
         post_request name, options
       end
 
+      # 【Pay-easy決済】
+      #  5.1.2.1. 取引登録
+      #  これ以降の決済取引で必要となる取引IDと取引パスワードの発行を行い、取引を開始します。
+      def entry_tran_pay_easy(options = {})
+        name = "EntryTranPayEasy.idPass"
+        required = [:order_id, :amount]
+        assert_required_options(required, options)
+        post_request name, options
+      end
+
       ## 2.2.2.2.決済実行
       # 指定されたサイトに会員を登録します。
       # return
@@ -136,6 +146,16 @@ module GMO
       def exec_tran_cvs(options = {})
         name = "ExecTranCvs.idPass"
         required = [:access_id, :access_pass, :order_id, :convenience, :customer_name, :tel_no, :receipts_disp_11, :receipts_disp_12, :receipts_disp_13]
+        assert_required_options(required, options)
+        post_request name, options
+      end
+
+      # 【Pay-easy決済】
+      # 5.1.2.2. 決済実行
+      # お客様が入力した情報で後続の決済センターと通信を行い決済を実施し、結果を返します。
+      def exec_tran_pay_easy(options = {})
+        name = "ExecTranPayEasy.idPass"
+        required = [:access_id, :access_pass, :order_id, :customer_name, :customer_kana, :tel_no, :receipts_disp_11, :receipts_disp_12, :receipts_disp_13]
         assert_required_options(required, options)
         post_request name, options
       end

--- a/spec/gmo/shop_api_spec.rb
+++ b/spec/gmo/shop_api_spec.rb
@@ -71,6 +71,24 @@ describe "GMO::Payment::ShopAPI" do
     end
   end
 
+  describe "#entry_tran_pay_easy" do
+    it "gets data about a transaction", :vcr do
+      order_id = @order_id
+      result = @service.entry_tran_pay_easy({
+        :order_id => order_id,
+        :amount => 100
+      })
+      result["AccessID"].nil?.should_not be_true
+      result["AccessPass"].nil?.should_not be_true
+    end
+
+    it "got error if missing options", :vcr do
+      lambda {
+        result = @service.entry_tran_pay_easy()
+      }.should raise_error("Required order_id, amount were not provided.")
+    end
+  end
+
   describe "#exec_tran" do
     it "gets data about a transaction", :vcr do
       order_id = generate_id
@@ -191,6 +209,43 @@ describe "GMO::Payment::ShopAPI" do
       lambda {
         result = @service.exec_tran_cvs()
       }.should raise_error("Required access_id, access_pass, order_id, convenience, customer_name, tel_no, receipts_disp_11, receipts_disp_12, receipts_disp_13 were not provided.")
+    end
+  end
+
+  describe "#exec_tran_pay_easy" do
+    it "gets data about a transaction", :vcr do
+      order_id = generate_id
+      result = @service.entry_tran_pay_easy({
+        :order_id => order_id,
+        :amount => 100
+      })
+      access_id = result["AccessID"]
+      access_pass = result["AccessPass"]
+      result = @service.exec_tran_pay_easy({
+        :order_id      => order_id,
+        :access_id     => access_id,
+        :access_pass   => access_pass,
+        :customer_name => 'ペイ太郎',
+        :customer_kana => 'ペイタロウ',
+        :tel_no        => '0300000001',
+        :receipts_disp_11 => 'RSpec Helpdesk',
+        :receipts_disp_12 => '0300000001',
+        :receipts_disp_13 => '00:00-00:15'
+      })
+      result["OrderID"].nil?.should_not be_true
+      result["CustID"].nil?.should_not be_true
+      result["BkCode"].nil?.should_not be_true
+      result["ConfNo"].nil?.should_not be_true
+      result["EncryptReceiptNo"].nil?.should_not be_true
+      result["PaymentTerm"].nil?.should_not be_true
+      result["TranDate"].nil?.should_not be_true
+      result["CheckString"].nil?.should_not be_true
+    end
+
+    it "got error if missing options", :vcr do
+      lambda {
+        result = @service.exec_tran_pay_easy()
+      }.should raise_error("Required access_id, access_pass, order_id, customer_name, customer_kana, tel_no, receipts_disp_11, receipts_disp_12, receipts_disp_13 were not provided.")
     end
   end
 


### PR DESCRIPTION
Pay-easy決済に対応するために`entry_tran_pay_easy`と`exec_tran_pay_easy`をShopAPIに追加しました。宜しくお願い致します。