### PR TITLE
fix spec

### DIFF
--- a/spec/gmo/shop_api_spec.rb
+++ b/spec/gmo/shop_api_spec.rb
@@ -227,7 +227,7 @@ describe "GMO::Payment::ShopAPI" do
     it "got error if missing options", :vcr do
       lambda {
         result = @service.exec_tran_cvs()
-      }.should raise_error("Required access_id, access_pass, order_id, convenience, customer_name, tel_no, receipts_disp_11, receipts_disp_12, receipts_disp_13 were not provided.")
+      }.should raise_error(ArgumentError, "Required access_id, access_pass, order_id, convenience, customer_name, customer_kana, tel_no, receipts_disp_11, receipts_disp_12, receipts_disp_13 were not provided.")
     end
   end
 

--- a/spec/support/config.yml
+++ b/spec/support/config.yml
@@ -3,3 +3,5 @@ shop_pass: 1
 site_id: tsite0001
 site_pass: 1
 host: pt01.mul-pay.jp
+token_member_id: 1
+token: 1


### PR DESCRIPTION
make pass failed spec

```
 be rspec --color                                                                                                                                  [18:45:03]
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
..................................................................

Deprecation Warnings:

`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics) or `be true` (for exact `== true` equality) instead. Called from /Users/kazuya.matsumoto/.ghq/github.com/kazuooooo/gmo-payment-ruby/spec/gmo/shop_and_site_api_spec.rb:82:in `block (3 levels) in <top (required)>'.
`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics) or `be true` (for exact `== true` equality) instead. Called from /Users/kazuya.matsumoto/.ghq/github.com/kazuooooo/gmo-payment-ruby/spec/gmo/shop_and_site_api_spec.rb:83:in `block (3 levels) in <top (required)>'.
`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional semantics) or `be true` (for exact `== true` equality) instead. Called from /Users/kazuya.matsumoto/.ghq/github.com/kazuooooo/gmo-payment-ruby/spec/gmo/shop_and_site_api_spec.rb:84:in `block (3 levels) in <top (required)>'.
Too many uses of deprecated '`be_true`'. Pass `--deprecation-out` or set `config.deprecation_stream` to a file for full output.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

138 deprecation warnings total

Finished in 0.13265 seconds
66 examples, 0 failures
Coverage report generated for RSpec to /Users/kazuya.matsumoto/.ghq/github.com/kazuooooo/gmo-payment-ruby/coverage. 275 / 292 LOC (94.18%) covered.
```