### PR TITLE
Add :payment_type to INPUT_PARAMS

### DIFF
--- a/lib/gmo/const.rb
+++ b/lib/gmo/const.rb
@@ -83,6 +83,7 @@ module GMO
       :pa_res                => "PaRes",
       :pay_times             => "PayTimes",
       :pay_type              => "PayType",
+      :payment_type          => "PaymentType",
       :payment_term_day      => "PaymentTermDay",
       :payment_term_sec      => "PaymentTermSec",
       :receipts_disp_1       => "ReceiptsDisp1",


### PR DESCRIPTION
2017年末頃、PayEasy決済実行時に`PaymentType=E` を付加することが必要になると GMO から仕様変更の知らせがありました。このパラメーターが含まれている場合、新しい決済プロトコルが使われます。古いほうは廃止予定とのことです。
また、`PaymentType=E`を付加した場合、GMO上に作成される決済情報の `お客様番号` が10桁（今までは 11桁）に、`確認番号` が6桁（今までは 4桁）になります。

詳細につきましては、マニュアル「035_プロトコルタイプ（マルチ決済_インタフェース仕様）_1.63.pdf」の
* 5.1.2.2. 決済実行
* 5.1.2.3. 金融機関選択画面の表示（PaymentType：E の場合） 
* 5.1.2.4. 金融機関選択画面の表示（※廃止予定）

をご参照ください。
