### PR TITLE
add new parameter for pay-easy

### DIFF
--- a/lib/gmo/const.rb
+++ b/lib/gmo/const.rb
@@ -83,6 +83,7 @@ module GMO
       :pa_res                => "PaRes",
       :pay_times             => "PayTimes",
       :pay_type              => "PayType",
+      :payment_type          => "PaymentType",
       :payment_term_day      => "PaymentTermDay",
       :payment_term_sec      => "PaymentTermSec",
       :receipts_disp_1       => "ReceiptsDisp1",


### PR DESCRIPTION
GMO-PG社の仕様変更*1 に対応するため、"PaymentType" をPOSTできる必要があります。
ご確認いただけますと幸いです。

*1：pay-easy の場合ｈ、PaymentType: E を送信する必要があるとのことです。