### PR TITLE
Support CvsCancel API

### DIFF
--- a/fixtures/vcr_cassettes/GMO_Payment_ShopAPI/_cvs_cancel_gets_data_about_a_transaction.yml
+++ b/fixtures/vcr_cassettes/GMO_Payment_ShopAPI/_cvs_cancel_gets_data_about_a_transaction.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<HOST>/payment/EntryTranCvs.idPass
+    body:
+      encoding: UTF-8
+      string: OrderID=1362106772&Amount=100&ShopID=<SHOP_ID>&ShopPass=<SHOP_PASS>
+    headers:
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 01 Mar 2013 02:59:32 GMT
+      Connection:
+      - close
+      Content-Type:
+      - text/plain;charset=Windows-31J
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: US-ASCII
+      string: AccessID=3618be802c7ac572414274731e50cb6c&AccessPass=4099664bd4b110800e09805539d1d7b5
+    http_version:
+  recorded_at: Fri, 01 Mar 2013 02:59:33 GMT
+- request:
+    method: post
+    uri: https://<HOST>/payment/CvsCancel.idPass
+    body:
+      encoding: UTF-8
+      string: OrderID=1365660033&AccessID=3618be802c7ac572414274731e50cb6c&AccessPass=4099664bd4b110800e09805539d1d7b5&ShopID=<SHOP_ID>&ShopPass=<SHOP_PASS>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - '*/*'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 11 Apr 2013 06:00:33 GMT
+      Connection:
+      - close
+      Content-Type:
+      - text/plain;charset=Windows-31J
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: US-ASCII
+      string: OrderID=1365660033&Status=CANCEL
+    http_version:
+  recorded_at: Thu, 11 Apr 2013 06:00:33 GMT
+recorded_with: VCR 2.4.0

--- a/lib/gmo/shop_api.rb
+++ b/lib/gmo/shop_api.rb
@@ -425,6 +425,16 @@ module GMO
         post_request name, options
       end
 
+      # 【コンビニ払い】
+      ## 2.2.2.1. 支払停止
+      # コンビニ決済センターとの通信を行い取引の支払停止処理を行います。
+      def cvs_cancel(options = {})
+        name = "CvsCancel.idPass"
+        required = [:access_id, :access_pass, :order_id]
+        assert_required_options(required, options)
+        post_request name, options
+      end
+
       ## 2.16.2.1.取引状態参照
       # 指定したオーダーID の取引情報を取得します。
       def search_trade(options = {})

--- a/spec/gmo/shop_api_spec.rb
+++ b/spec/gmo/shop_api_spec.rb
@@ -694,6 +694,32 @@ describe "GMO::Payment::ShopAPI" do
     end
   end
 
+  describe "#cvs_cancel" do
+    it "gets data about a transaction", :vcr do
+      order_id = generate_id
+      result = @service.entry_tran_cvs({
+        :order_id => order_id,
+        :amount => 100
+      })
+      access_id = result["AccessID"]
+      access_pass = result["AccessPass"]
+      result = @service.cvs_cancel({
+        :order_id => order_id,
+        :access_id => access_id,
+        :access_pass => access_pass,
+      })
+
+      result["OrderID"].nil?.should_not be_truthy
+      result["Status"].nil?.should_not be_truthy
+    end
+
+    it "got error if missing options", :vcr do
+      lambda {
+        result = @service.cvs_cancel()
+      }.should raise_error("Required access_id, access_pass, order_id were not provided.")
+    end
+  end
+
   describe "#search_trade" do
     it "gets data about order", :vcr do
       order_id = @order_id


### PR DESCRIPTION
Hi. Thank you for developing a useful gem.

I added support for the `CvsCancel.idPass` API that stops payment processing for convenience store payments.

If this repository is still active, please check this PR.