### PR TITLE
Add `search_type` to INPUT_PARAMS for Shop API `/payment/SearchCardDetail.idPass`

### DIFF
--- a/lib/gmo/const.rb
+++ b/lib/gmo/const.rb
@@ -140,7 +140,8 @@ module GMO
       :delivery_place_phone  => "DeliveryPlacePhone",
       :lang_cd               => "LangCd",
       :user_info             => "UserInfo",
-      :package_name          => "PackageName"
+      :package_name          => "PackageName",
+      :search_type           => "SearchType"
     }.freeze
 
     API_ERROR_MESSAGES_EN = {


### PR DESCRIPTION
Shop APIにカード属性照会(SearchCardDetail) APIがありますが、こちらに `SearchType` というパラメーターがありますが、こちらのパラメーターが `INPUT_PARAMS` に定義されておらず、切捨されてしまうため、サポートするよう対応しました。
（PGマルチペイメントサービス クレジットカード決済利用マニュアルの4.3.12.1 カード属性照会(SearchCardDetail)を参照しています）
こちらの修正にてテスト環境では想定どおり動作致しました。