### PR TITLE
Specify an input encoding to `NKF` to avoid misjudgement

### DIFF
--- a/lib/gmo.rb
+++ b/lib/gmo.rb
@@ -42,7 +42,7 @@ module GMO
         key_values = result.body.to_s.split('&').map { |str| str.split('=', 2) }.flatten
         response = Hash[*key_values]
         # converting to UTF-8
-        body = response = Hash[response.map { |k,v| [k, NKF.nkf('-w',v)] }]
+        body = response = Hash[response.map { |k,v| [k, NKF.nkf('-S -w',v)] }]
         # Check for errors if provided a error_checking_block
         yield(body) if error_checking_block
         # Return result


### PR DESCRIPTION
NKF sometimes misjudges an encoding. For example `ｶｿｳｼﾃﾝ` isn't judged correctly.

```ruby
NKF.guess('ｶｿｳｼﾃﾝ'.encode("Windows-31J"))
=> #<Encoding:EUC-JP>
```

This causes misconverting. The previous word converts like this.

```ruby
NKF.nkf('-w', 'ｶｿｳｼﾃﾝ'.encode("Windows-31J"))
=> "郷骸竹"
```

The specifying input encoding prevent this.

```ruby
NKF.nkf('-S -w', 'ｶｿｳｼﾃﾝ'.encode("Windows-31J"))
=> "カソウシテン"
```

Fixes #33.