### PR TITLE
銀行振込（バーチャル口座 あおぞら）の追加

### DIFF
--- a/fixtures/vcr_cassettes/GMO_Payment_ShopAPI/_entry_tran_ganb_gets_data_about_a_transaction.yml
+++ b/fixtures/vcr_cassettes/GMO_Payment_ShopAPI/_entry_tran_ganb_gets_data_about_a_transaction.yml
@@ -1,0 +1,35 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<HOST>/payment/EntryTranGANB.idPass
+    body:
+      encoding: UTF-8
+      string: OrderID=1696341308&Amount=100&ShopID=<SHOP_ID>&ShopPass=<SHOP_PASS>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 03 Oct 2023 13:55:08 GMT
+      Content-Type:
+      - text/plain;charset=Shift_JIS
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: OrderID=1696341308&AccessID=e297cc560cc91e226d0affef26f9ca10&AccessPass=e81b3b1af08488e16d73dcf5e0ecd6b0
+  recorded_at: Tue, 03 Oct 2023 13:55:08 GMT
+recorded_with: VCR 6.1.0

--- a/fixtures/vcr_cassettes/GMO_Payment_ShopAPI/_exec_tran_ganb_gets_data_about_a_transaction.yml
+++ b/fixtures/vcr_cassettes/GMO_Payment_ShopAPI/_exec_tran_ganb_gets_data_about_a_transaction.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<HOST>/payment/EntryTranGANB.idPass
+    body:
+      encoding: UTF-8
+      string: OrderID=1696418445&Amount=100&ShopID=<SHOP_ID>&ShopPass=<SHOP_PASS>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 04 Oct 2023 11:20:50 GMT
+      Content-Type:
+      - text/plain;charset=Shift_JIS
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: OrderID=1696418445&AccessID=ef73b56f6daf8fb36fa8e0a2133a0613&AccessPass=f9e832b3b9c886b70d98c5e857571033
+  recorded_at: Wed, 04 Oct 2023 11:20:45 GMT
+- request:
+    method: post
+    uri: https://<HOST>/payment/ExecTranGANB.idPass
+    body:
+      encoding: UTF-8
+      string: OrderID=1696418445&AccessID=ef73b56f6daf8fb36fa8e0a2133a0613&AccessPass=f9e832b3b9c886b70d98c5e857571033&ClientField1=%89%C1%96%BF%93X%8E%A9%97R%8D%80%96%DA1%82%C5%82%B7%81B&ClientField2=%89%C1%96%BF%93X%8E%A9%97R%8D%80%96%DA2%82%C5%82%B7%81B&ClientField3=%89%C1%96%BF%93X%8E%A9%97R%8D%80%96%DA3%82%C5%82%B7%81B&=irai%40example.com&TradeDays=3&TradeReason=%8E%E6%88%F8%8E%96%97R%82%C5%82%B7%81B&TradeClientName=%88%CB%97%8A%89%D4%8Eq&ShopID=<SHOP_ID>&ShopPass=<SHOP_PASS>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 04 Oct 2023 11:21:05 GMT
+      Content-Type:
+      - text/plain;charset=Shift_JIS
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        QWNjZXNzSUQ9ZWY3M2I1NmY2ZGFmOGZiMzZmYThlMGEyPFRPS0VOPjMzYTA2PFRPS0VOPjMmQmFua0NvZGU9MDM8VE9LRU4+MCZCYW5rTmFtZT283i200bUtsbW/3tfIwsQmQnJhbmNoQ29kZT01MDMmQnJhbmNoTmFtZT22v7O8w90mQWNjb3VudFR5cGU9PFRPS0VOPiZBY2NvdW50TnVtYmVyPTg5Mjk2OTYmQWNjb3VudEhvbGRlck5hbWU9w73EvK6vzN8mQXZhaWxhYmxlRGF0ZT0yMDIzPFRPS0VOPjAwNw==
+  recorded_at: Wed, 04 Oct 2023 11:21:00 GMT
+recorded_with: VCR 6.1.0

--- a/lib/gmo/shop_api.rb
+++ b/lib/gmo/shop_api.rb
@@ -83,6 +83,16 @@ module GMO
         post_request name, options
       end
 
+      # 【銀行振込（バーチャル口座 あおぞら）】
+      #  取引登録
+      #  オーダーIDを指定して取引を登録します。
+      def entry_tran_ganb(options = {})
+        name = "EntryTranGANB.idPass"
+        required = [:order_id, :amount]
+        assert_required_options(required, options)
+        post_request name, options
+      end
+
       # 【LINE Pay決済】
       #  20.1.2.1. 取引登録
       #  これ以降の決済取引で必要となる取引IDと取引パスワードの発行を行い、取引を開始します。
@@ -338,6 +348,16 @@ module GMO
       def exec_tran_paypal(options = {})
         name = "ExecTranPaypal.idPass"
         required = [:access_id, :access_pass, :order_id, :item_name, :redirect_url]
+        assert_required_options(required, options)
+        post_request name, options
+      end
+
+      # 【銀行振込（バーチャル口座 あおぞら）】
+      # 決済実行
+      # 登録された取引に対してバーチャル口座を発行します。
+      def exec_tran_ganb(options = {})
+        name = "ExecTranGANB.idPass"
+        required = [:access_id, :access_pass, :order_id]
         assert_required_options(required, options)
         post_request name, options
       end

--- a/spec/gmo/shop_api_spec.rb
+++ b/spec/gmo/shop_api_spec.rb
@@ -117,6 +117,25 @@ describe "GMO::Payment::ShopAPI" do
     end
   end
 
+  describe "#entry_tran_ganb" do
+    it "gets data about a transaction", :vcr do
+      order_id = @order_id
+      result = @service.entry_tran_ganb({
+        :order_id => order_id,
+        :amount => 100
+      })
+      result["AccessID"].nil?.should_not be_truthy
+      result["AccessPass"].nil?.should_not be_truthy
+    end
+
+    it "got error if missing options", :vcr do
+      lambda {
+        result = @service.entry_tran_ganb()
+      }.should raise_error("Required order_id, amount were not provided.")
+    end
+  end
+
+
   describe "#entry_tran_linepay" do
     it "gets data about a transaction", :vcr do
       order_id = @order_id
@@ -472,6 +491,45 @@ describe "GMO::Payment::ShopAPI" do
       lambda {
         result = @service.exec_tran_paypal()
       }.should raise_error("Required access_id, access_pass, order_id, item_name, redirect_url were not provided.")
+    end
+  end
+
+  describe "#exec_tran_ganb" do
+    it "gets data about a transaction", :vcr do
+      order_id = generate_id
+      result = @service.entry_tran_ganb({
+        :order_id => order_id,
+        :amount => 100
+      })
+      access_id = result["AccessID"]
+      access_pass = result["AccessPass"]
+      result = @service.exec_tran_ganb({
+        :order_id      => order_id,
+        :access_id     => access_id,
+        :access_pass   => access_pass,
+        :client_field_1 => '加盟店自由項目1です。',
+        :client_field_2 => '加盟店自由項目2です。',
+        :client_field_3 => '加盟店自由項目3です。',
+        :account_holder_optional_name => 'コウザタロウ',
+        :trade_days        => '3',
+        :trade_reason => '取引事由です。',
+        :trade_client_name => '依頼花子',
+        :trade_client_mailaddress => 'irai@example.com'
+      })
+      result["BankCode"].nil?.should_not be_truthy
+      result["BankName"].nil?.should_not be_truthy
+      result["BranchCode"].nil?.should_not be_truthy
+      result["BranchName"].nil?.should_not be_truthy
+      result["AccountType"].nil?.should_not be_truthy
+      result["AccountNumber"].nil?.should_not be_truthy
+      result["AccountHolderName"].nil?.should_not be_truthy
+      result["AvailableDate"].nil?.should_not be_truthy
+    end
+
+    it "got error if missing options", :vcr do
+      lambda {
+        result = @service.exec_tran_ganb()
+      }.should raise_error("Required access_id, access_pass, order_id were not provided.")
     end
   end
 


### PR DESCRIPTION
銀行振込（バーチャル口座 あおぞら）のEntryTran と ExecTran を追加しました。

## 参照
- [GMOPG マルペイDocs 銀行振込(バーチャル口座 あおぞら) API一覧](https://gmopg_docs:PF%cwa$GmCC@docs.mul-pay.jp/ganb/api)