### PR TITLE
Add `nkf` as a dependency

### DIFF
--- a/gmo.gemspec
+++ b/gmo.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency "rack"
   gem.add_runtime_dependency "multi_json"
+  gem.add_runtime_dependency "nkf"
   gem.add_development_dependency "rspec", "~> 3"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "vcr"


### PR DESCRIPTION
Since Ruby 3.3.0, RubyGems and Bundler warn if users require the gems that will become the bundled gems in the future version of Ruby. 
Please see the "Standard library updates" section for the details. https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

`gmo` uses `nkf`. This fixes the following warning.

```
gmo-payment-ruby/gmo-payment-ruby/lib/gmo.rb:2: warning: nkf was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add nkf to your Gemfile or gemspec.
```

Ref:  https://github.com/t-k/gmo-payment-ruby/actions/runs/9106594362/job/25034049847#step:4:6