### PR TITLE
CI against Ruby 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v3

--- a/gmo.gemspec
+++ b/gmo.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
   gem.add_development_dependency "vcr"
   gem.add_development_dependency "webmock"
+  gem.add_development_dependency "ostruct"
 end

--- a/spec/gmo/remittance_api_spec.rb
+++ b/spec/gmo/remittance_api_spec.rb
@@ -1,6 +1,7 @@
 # Encoding: UTF-8
 
 require "spec_helper"
+require "ostruct"
 
 describe "GMO::Payment::RemittanceAPI" do
 


### PR DESCRIPTION
This commit adds Ruby 3.4 to the test matrix to ensure to work the gem with it.

Also, this PR makes `ostruct` an explicit dependency.
`ostruct` will no longer be part of the default gems since Ruby 3.5.0. So we need to add `ostruct` to the gemspec.
Ref: https://bugs.ruby-lang.org/issues/20309