### PR TITLE
net-http 0.7.0+ requires to explicitly setting content type

### DIFF
--- a/lib/gmo/http_services.rb
+++ b/lib/gmo/http_services.rb
@@ -44,7 +44,8 @@ module GMO
                 headers = { "Content-Type" => "application/json" }
                 h.post(path, args.to_json, headers)
               else
-                h.post(path, encode_params(args))
+                headers = { "Content-Type" => "application/x-www-form-urlencoded" }
+                h.post(path, encode_params(args), headers)
               end
             else
               h.get("#{path}?#{encode_params(args)}")

--- a/spec/gmo/net_http_service_spec.rb
+++ b/spec/gmo/net_http_service_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+class FakeNetHTTPService
+  include GMO::NetHTTPService
+end
+
+describe "GMO::NetHTTPService" do
+
+  describe "#make_request" do
+    let(:mock_http) { double("Net::HTTP") }
+    let(:mock_http_session) { double("Net::HTTP session") }
+    let(:mock_response) { double("Net::HTTPResponse", code: "200", body: "AccessID=test123") }
+
+    before do
+      allow(Net::HTTP).to receive(:new).and_return(mock_http)
+      allow(mock_http).to receive(:use_ssl=)
+      allow(mock_http).to receive(:start).and_yield(mock_http_session)
+    end
+
+    describe "Content-Type header for form-encoded POST requests" do
+      it "sets Content-Type to application/x-www-form-urlencoded" do
+        expect(mock_http_session).to receive(:post) do |path, body, headers|
+          expect(path).to eq("/payment/EntryTran.idPass")
+          expect(headers["Content-Type"]).to eq("application/x-www-form-urlencoded")
+          mock_response
+        end
+
+        FakeNetHTTPService.make_request(
+          "/payment/EntryTran.idPass",
+          { "ShopID" => "shop123", "OrderID" => "order456" },
+          "post",
+          { :host => "example.com" }
+        )
+      end
+
+      it "properly encodes form parameters" do
+        expect(mock_http_session).to receive(:post) do |path, body, headers|
+          expect(path).to eq("/payment/EntryTran.idPass")
+          expect(body).to include("ShopID=")
+          expect(body).to include("OrderID=")
+          expect(headers["Content-Type"]).to eq("application/x-www-form-urlencoded")
+          mock_response
+        end
+
+        FakeNetHTTPService.make_request(
+          "/payment/EntryTran.idPass",
+          { "ShopID" => "shop123", "OrderID" => "order456" },
+          "post",
+          { :host => "example.com" }
+        )
+      end
+    end
+
+    describe "Content-Type header for JSON POST requests" do
+      it "sets Content-Type to application/json for .json paths" do
+        expect(mock_http_session).to receive(:post) do |path, body, headers|
+          expect(path).to eq("/payment/EntryTran.json")
+          expect(headers["Content-Type"]).to eq("application/json")
+          mock_response
+        end
+
+        FakeNetHTTPService.make_request(
+          "/payment/EntryTran.json",
+          { "ShopID" => "shop123" },
+          "post",
+          { :host => "example.com" }
+        )
+      end
+    end
+
+    describe "GET requests" do
+      it "appends parameters to query string without Content-Type header" do
+        expect(mock_http_session).to receive(:get) do |path_with_query|
+          expect(path_with_query).to include("/payment/SearchTrade.idPass?")
+          expect(path_with_query).to include("ShopID=")
+          mock_response
+        end
+
+        FakeNetHTTPService.make_request(
+          "/payment/SearchTrade.idPass",
+          { "ShopID" => "shop123" },
+          "get",
+          { :host => "example.com" }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
net-http v0.7.0 (released Oct 2025) removed the automatic `Content-Type: application/x-www-form-urlencoded` header for POST requests. Without this header, GMO servers can't parse form parameters, resulting in errors like `E01190001 "Site ID not specified".`

問題: net-http v0.7.0（2025年10月リリース）で、POSTリクエストの`Content-Type: application/x-www-form-urlencoded`ヘッダーの自動付与が廃止されました。このヘッダーがないと、GMOサーバーがフォムパラメータを解析できず、E01190001「SiteIDが指定されていません」などのエラーが発生します。

### net-http Content-Type Change

Version: v0.7.0
Released: October 31, 2025
PR: https://github.com/ruby/net-http/pull/207 - "Don't set content type by default"
