### PR TITLE
Bump version to 0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+## 0.5.9
+- net-http 0.7.0+でcontent typeを明示的に設定する必要がある問題を修正 [#79](https://github.com/t-k/gmo-payment-ruby/pull/79) (Thanks [@johnnyshields](https://github.com/johnnyshields))
+
 ## 0.5.8
 - クレジットカード決済の3Dセキュア2.0に対応 [#76](https://github.com/t-k/gmo-payment-ruby/pull/76)
   - 3DS2.0認証実行 (`tds2_auth`)

--- a/lib/gmo/version.rb
+++ b/lib/gmo/version.rb
@@ -1,3 +1,3 @@
 module GMO
-  VERSION = "0.5.8"
+  VERSION = "0.5.9"
 end


### PR DESCRIPTION
## 概要
バージョン0.5.9へのバージョンアップ

## 変更内容
- net-http 0.7.0+でcontent typeを明示的に設定する必要がある問題を修正 (#79)

## チェックリスト
- [x] CHANGELOGを更新
- [x] lib/gmo/version.rbを更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)